### PR TITLE
When components are loaded for a second time the editor is initialize…

### DIFF
--- a/BlazorMonaco/BlazorMonaco.csproj
+++ b/BlazorMonaco/BlazorMonaco.csproj
@@ -12,7 +12,7 @@
 
 - Monaco Editor v0.20.0
 - Blazor v3.2.0</Description>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <PackageProjectUrl>https://serdarciplak.github.io/BlazorMonaco/</PackageProjectUrl>
     <PackageReleaseNotes>See the change log for release notes:
 https://github.com/serdarciplak/BlazorMonaco/blob/master/CHANGELOG.md</PackageReleaseNotes>

--- a/BlazorMonaco/wwwroot/jsInterop.js
+++ b/BlazorMonaco/wwwroot/jsInterop.js
@@ -26,20 +26,17 @@ window.blazorMonaco.editor = {
         if (options == null)
             options = {};
 
-        var editorExists = this.getEditorById(id, true) !== null;
-        if (editorExists) {
-            options.value = this.getValue(id);
+        var oldEditor = this.getEditorById(id, true);
+        if (oldEditor !== null) {
+            options.value = oldEditor.getValue();
+            window.blazorMonaco.editors.splice(window.blazorMonaco.editors.findIndex(item => item.id === id), 1);
+            oldEditor.dispose();
         }
 
         if (typeof monaco === 'undefined')
             console.log("WARNING : Please check that you have the script tag for editor.main.js in your index.html file");
 
         var editor = monaco.editor.create(document.getElementById(id), options);
-
-        //if it already exists remove it
-      if (!editorExists)
-            window.blazorMonaco.editors.splice(window.blazorMonaco.editors.findIndex(item => item.id === id), 1);
-      
         window.blazorMonaco.editors.push({ id: id, editor: editor });
     },
 

--- a/BlazorMonaco/wwwroot/jsInterop.js
+++ b/BlazorMonaco/wwwroot/jsInterop.js
@@ -23,16 +23,23 @@ window.blazorMonaco.editor = {
     },
 
     create: function (id, options) {
-        if (window.blazorMonaco.editors.find(e => e.id === id))
-            return;
-        
         if (options == null)
             options = {};
+
+        var editorExists = this.getEditorById(id, true) !== null;
+        if (editorExists) {
+            options.value = this.getValue(id);
+        }
 
         if (typeof monaco === 'undefined')
             console.log("WARNING : Please check that you have the script tag for editor.main.js in your index.html file");
 
         var editor = monaco.editor.create(document.getElementById(id), options);
+
+        //if it already exists remove it
+      if (!editorExists)
+            window.blazorMonaco.editors.splice(window.blazorMonaco.editors.findIndex(item => item.id === id), 1);
+      
         window.blazorMonaco.editors.push({ id: id, editor: editor });
     },
 
@@ -100,12 +107,16 @@ window.blazorMonaco.editor = {
 
     //#region Instance methods
 
-    getEditorById: function (id) {
+    getEditorById: function (id, unobstrusive = false) {
         let editorHolder = window.blazorMonaco.editors.find(e => e.id === id);
-        if (!editorHolder)
+        if (!editorHolder) {
+            if (unobstrusive) return null;
             throw "Couldn't find the editor with id: " + id + " editors.length: " + window.blazorMonaco.editors.length;
-        else if (!editorHolder.editor)
+        }
+        else if (!editorHolder.editor) {
+            if (unobstrusive) return null;
             throw "editor is null for editorHolder: " + editorHolder;
+        }
         return editorHolder.editor;
     },
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.3.1
+* Fixed a bug where recreating the editor instance fails.
+
 ## 1.3.0
 * Added support for DeltaDecorations and ResetDeltaDecorations.
 


### PR DESCRIPTION
…d with the old value

First off; an option to reattach a JavaScript monaco editor to the HTML element would be preferable, but I could not find it. So I came up with this.

I find when I have the editor in a component and I open the component all is fine. But then when navigate go to a different component in the content pane and then come back, the HTML tag is there but the item is not created.
I recreated it here as an example: https://github.com/Monedula1/DemoBlazorWASM
In JavaScript I can simply create the editor again but copy the value (or whatever I find interesting) from it before I recreate it:
```
var knownvalue = editor.getValue();

var editor = monaco.editor.create(document.getElementById("container"), {
	language: "javascript"
});

editor.setValue(knownvalue);
```
Calling `layout()` in Blazor doesn't seem to work since it has lost the reference to the html. So I made this pull request so the editor would always be created.
Basically it does what the JavaScript up here also does. It sees if there was already an editor of the same name. If so the value is placed in memory, the editor is removed from the known editors and it is added again with the value gotten from the previous instance.