### PR TITLE
Where is BlazorMonacoGlobals?

### DIFF
--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -22,7 +22,7 @@
 
 - Class, property and object names are now better aligned with the original Monaco Editor JavaScript library. So, you need to update your usages with the new names. You'll notice right away that `MonacoEditor` is renamed to `StandaloneCodeEditor`, and `MonacoDiffEditor` is renamed to `StandaloneDiffEditor`. Based on what you use, you'll notice more changes. Just check the namespace and class definitions. If Microsoft didnot remove that thing in the new Monaco Editor version, it'll be there with a new name similar to the old one.
 
-- Static methods in the `MonacoEditor` and `MonacoEditorBase` classes (e.g. `SetTheme`, `Colorize`, etc) are removed from the editor class and grouped together under a new class named `BlazorMonacoGlobals`.
+- Static methods in the `MonacoEditor` and `MonacoEditorBase` classes (e.g. `SetTheme`, `Colorize`, etc) are removed from the editor class and grouped together under a new class named `Global`.
 
 - Event callback methods used to have a parameter for the source editor instance that raised the event. It's removed for following the original Monaco Editor implementation.
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ private void OnKeyUpModified(KeyboardEvent keyboardEvent)
 * You can define custom themes using the `DefineTheme` method. Just make sure that you don't call `DefineTheme` before any editor instance is initialized. BlazorMonaco needs an `IJSRuntime` instance to call JavaScript methods and it gets one when the first instance is initialized.
 
 ```csharp
-await BlazorMonacoGlobals.DefineTheme("my-custom-theme", new StandaloneThemeData
+await BlazorMonaco.Editor.Global.DefineTheme("my-custom-theme", new StandaloneThemeData
 {
 	Base = "vs-dark",
 	Inherit = true,
@@ -179,7 +179,7 @@ await BlazorMonacoGlobals.DefineTheme("my-custom-theme", new StandaloneThemeData
 * After defining your custom theme, you can call the `SetTheme` method at any time with your custom theme name to set it active.
 
 ```csharp
-await BlazorMonacoGlobals.SetTheme("my-custom-theme");
+await BlazorMonaco.Editor.Global.SetTheme("my-custom-theme");
 ```
 
 ### DeltaDecorations


### PR DESCRIPTION
I couldn't find "BlazorMonacoGlobals" stated in the document?
Is it moved to BlazorMonaco.Editor.Global or am I missing it?
At least Intellisense and search box on GitHub didn't show the result.