### PR TITLE
Fixed bug:  "Converting circular structure to JSON" if using getAllDecorations()

### DIFF
--- a/BlazorMonaco/wwwroot/jsInterop.js
+++ b/BlazorMonaco/wwwroot/jsInterop.js
@@ -786,22 +786,26 @@ window.blazorMonaco.editor = {
 
         getLineDecorations: function (uriStr, lineNumber, ownerId, filterOutValidation) {
             let model = this.getModel(uriStr);
-            return model.getLineDecorations(lineNumber, ownerId, filterOutValidation);
+            let decorations = model.getLineDecorations(lineNumber, ownerId, filterOutValidation);
+            return this.compactDecorations(decorations);
         },
 
         getLinesDecorations: function (uriStr, startLineNumber, endLineNumber, ownerId, filterOutValidation) {
             let model = this.getModel(uriStr);
-            return model.getLinesDecorations(startLineNumber, endLineNumber, ownerId, filterOutValidation);
+            let decorations = model.getLinesDecorations(startLineNumber, endLineNumber, ownerId, filterOutValidation);
+            return this.compactDecorations(decorations);
         },
 
         getDecorationsInRange: function (uriStr, range, ownerId, filterOutValidation) {
             let model = this.getModel(uriStr);
-            return model.getDecorationsInRange(range, ownerId, filterOutValidation);
+            let decorations = model.getDecorationsInRange(range, ownerId, filterOutValidation);
+            return this.compactDecorations(decorations);
         },
 
         getAllDecorations: function (uriStr, ownerId, filterOutValidation) {
             let model = this.getModel(uriStr);
-            return model.getAllDecorations(ownerId, filterOutValidation);
+            let decorations = model.getAllDecorations(ownerId, filterOutValidation);
+            return this.compactDecorations(decorations);
         },
 
         getInjectedTextDecorations: function (uriStr, ownerId) {
@@ -811,7 +815,8 @@ window.blazorMonaco.editor = {
 
         getOverviewRulerDecorations: function (uriStr, ownerId, filterOutValidation) {
             let model = this.getModel(uriStr);
-            return model.getOverviewRulerDecorations(ownerId, filterOutValidation);
+            let decorations = model.getOverviewRulerDecorations(ownerId, filterOutValidation);
+            return this.compactDecorations(decorations);
         },
 
         normalizeIndentation: function (uriStr, str) {
@@ -852,6 +857,15 @@ window.blazorMonaco.editor = {
         setEOL: function (uriStr, eol) {
             let model = this.getModel(uriStr);
             return model.setEOL(eol);
+        },
+
+        compactDecorations: function (srcDecorations) {
+            let destDecorations = [];
+            for (let i = 0; i < srcDecorations.length; ++i) {
+                let srcDecoration = srcDecorations[i];
+                destDecorations.push({ id: srcDecoration.id, ownerId: srcDecoration.ownerId, range: srcDecoration.range, options: srcDecoration.options });
+            }
+            return destDecorations;
         },
 
         dispose: function (uriStr) {

--- a/SampleApp/Pages/Index.razor
+++ b/SampleApp/Pages/Index.razor
@@ -18,6 +18,9 @@
         <button @onclick="GetValue">Get Value</button>
     </div>
     <div style="margin:10px 0;">
+        <button @onclick="GetDecoration">Get Decoration</button>
+    </div>
+    <div style="margin:10px 0;">
         <button @onclick="AddCommand">Add Command (Ctrl+Enter)</button>
     </div>
     <div style="margin:10px 0;">
@@ -100,6 +103,16 @@
     {
         var val = await _editor.GetValue();
         Console.WriteLine($"value is: {val}");
+    }
+
+    private async Task GetDecoration()
+    {
+        var model = await _editor.GetModel();
+        var decorations = await model.GetAllDecorations(0, false);
+        foreach(var decoration in decorations)
+        {
+            Console.WriteLine($"Id: {decoration.Id}, OnwerId: {decoration.OwnerId}, Range: {decoration.Range.StartLineNumber}, {decoration.Range.StartColumn}, {decoration.Range.EndLineNumber}, {decoration.Range.EndColumn}");
+        }
     }
 
     private async Task AddCommand()


### PR DESCRIPTION
Calling getAllDecorations() returns internal members like parent ... These members seems to produce circular references while converting the decorations to json. To fix it, I added a method "compactDecorations()" which creates an array of decorations only containing the official members and call them in getAllDecorations() and other decoration-related methods.