### PR TITLE
feat: add dotnet 8 support

### DIFF
--- a/BlazorMonaco/BlazorMonaco.csproj
+++ b/BlazorMonaco/BlazorMonaco.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <RazorLangVersion>3.0</RazorLangVersion>
     <Authors>Serdar Ciplak</Authors>
     <RepositoryUrl>https://github.com/serdarciplak/BlazorMonaco</RepositoryUrl>
@@ -36,7 +36,10 @@ https://github.com/serdarciplak/BlazorMonaco/blob/master/CHANGELOG.md</PackageRe
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="7.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.0" />
   </ItemGroup>
-
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0" />
+  </ItemGroup>
   <ItemGroup>
     <None Include="icon.png">
       <Pack>True</Pack>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Some less-frequently used Monaco Editor features are currently missing, but a go
 
 Current version of BlazorMonaco :
 * Uses `Monaco Editor v0.34.1`
-* Supports `netstandard2.0`, `net5.0`, `net6.0` and `net7.0`
+* Supports `netstandard2.0`, `net5.0`, `net6.0`, `net7.0` and `net8.0`
 
 ## Demo
 

--- a/SampleApp/SampleApp.csproj
+++ b/SampleApp/SampleApp.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-	<TargetFramework>net7.0</TargetFramework>
+	<TargetFramework>net8.0</TargetFramework>
 	  <Nullable>enable</Nullable>
 	  <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SampleApp/wwwroot/css/app.css
+++ b/SampleApp/wwwroot/css/app.css
@@ -193,3 +193,38 @@ app {
 .decorationContentClass {
     background: lightblue;
 }
+
+
+.loading-progress {
+    position: relative;
+    display: block;
+    width: 8rem;
+    height: 8rem;
+    margin: 20vh auto 1rem auto;
+}
+
+.loading-progress circle {
+    fill: none;
+    stroke: #e0e0e0;
+    stroke-width: 0.6rem;
+    transform-origin: 50% 50%;
+    transform: rotate(-90deg);
+}
+
+.loading-progress circle:last-child {
+    stroke: #1b6ec2;
+    stroke-dasharray: calc(3.141 * var(--blazor-load-percentage, 0%) * 0.8), 500%;
+    transition: stroke-dasharray 0.05s ease-in-out;
+}
+
+.loading-progress-text {
+    position: absolute;
+    text-align: center;
+    font-weight: bold;
+    inset: calc(20vh + 3.25rem) 0 auto 0.2rem;
+}
+
+.loading-progress-text:after {
+    content: var(--blazor-load-percentage-text, "Loading");
+}
+

--- a/SampleApp/wwwroot/index.html
+++ b/SampleApp/wwwroot/index.html
@@ -12,7 +12,13 @@
 </head>
 
 <body>
-    <div id="app">Loading...</div>
+    <div id="app">
+        <svg class="loading-progress">
+            <circle r="40%" cx="50%" cy="50%" />
+            <circle r="40%" cx="50%" cy="50%" />
+        </svg>
+        <div class="loading-progress-text"></div>
+    </div>
 
     <div id="blazor-error-ui">
         An unhandled error has occurred.


### PR DESCRIPTION
Closes https://github.com/serdarciplak/BlazorMonaco/issues/114

Added dotnet 8 support for both the BlazorMonaco project & the SampleApp.

Was able to publish & run it locally.

![image](https://github.com/serdarciplak/BlazorMonaco/assets/16806427/86bff327-c70c-481f-b06f-0389d269af12)

Am using the prerelease SDK, should be the same for the release version.

![image](https://github.com/serdarciplak/BlazorMonaco/assets/16806427/666eee6a-f13b-480a-ab5d-f4a45d0c3598)



Also added in the loading spinner from the default msft blazor template as well.