### PR TITLE
When recreating editor overwrite value only if not specified

### DIFF
--- a/BlazorMonaco/wwwroot/jsInterop.js
+++ b/BlazorMonaco/wwwroot/jsInterop.js
@@ -71,7 +71,10 @@ window.blazorMonaco.editor = {
 
         var oldEditor = this.getEditor(id, true);
         if (oldEditor !== null) {
-            options.value = oldEditor.getValue();
+            if (options.value == null) {
+                options.value = oldEditor.getValue();
+            }
+
             window.blazorMonaco.editors.splice(window.blazorMonaco.editors.findIndex(item => item.id === id), 1);
             oldEditor.dispose();
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## vNext
+* Changed behaviour of overwriting options' value when recreating editor with the same ID - now options will be overwritten only if they do not specify value already.
+
 ## 3.2.0
 * Updated to Monaco Editor v0.46.0
 * Added support for net8.0


### PR DESCRIPTION
Related discussion: https://github.com/serdarciplak/BlazorMonaco/issues/136