### PR TITLE
Fixed lineNumbers option for server apps

### DIFF
--- a/BlazorMonaco/Bridge/Editor.cs
+++ b/BlazorMonaco/Bridge/Editor.cs
@@ -86,6 +86,9 @@ namespace BlazorMonaco.Editor
             return LineNumbersLambda?.Invoke(lineNumber) ?? lineNumber.ToString();
         }
 
+        public Task ReloadLineNumbers()
+            => JsRuntime.SafeInvokeAsync("blazorMonaco.editor.reloadLineNumbers", Id);
+
         #endregion
 
         /**

--- a/BlazorMonaco/wwwroot/jsInterop.js
+++ b/BlazorMonaco/wwwroot/jsInterop.js
@@ -32,7 +32,7 @@ window.blazorMonaco.editor = {
         return editorHolder == null ? null : editorHolder.editor;
     },
 
-    getEditorLineNumberFromDotnet: function (editorId, lineNumber) {
+    getEditorLineNumber: function (editorId, lineNumber) {
         const editorHolder = this.getEditorHolder(editorId, true);
         if (editorHolder == null) {
             return "";
@@ -86,7 +86,7 @@ window.blazorMonaco.editor = {
         if (optionValue.renderType == monaco.editor.RenderLineNumbersType.Custom) {
             editor.updateOptions({
                 lineNumbers: (lineNumber) => {
-                    return this.getEditorLineNumberFromDotnet(editorId, lineNumber);
+                    return this.getEditorLineNumber(editorId, lineNumber);
                 }
             });
         }
@@ -170,7 +170,7 @@ window.blazorMonaco.editor = {
 
         if (options.lineNumbers == "function") {
             options.lineNumbers = (lineNumber) => {
-                return this.getEditorLineNumberFromDotnet(id, lineNumber);
+                return this.getEditorLineNumber(id, lineNumber);
             };
         }
 
@@ -198,7 +198,7 @@ window.blazorMonaco.editor = {
 
         if (options.lineNumbers == "function") {
             options.lineNumbers = (lineNumber) => {
-                return this.getEditorLineNumberFromDotnet(id, lineNumber);
+                return this.getEditorLineNumber(id, lineNumber);
             };
         }
 

--- a/BlazorMonaco/wwwroot/jsInterop.js
+++ b/BlazorMonaco/wwwroot/jsInterop.js
@@ -6,6 +6,92 @@ window.blazorMonaco.editor = {
 
     //#region Utilities
 
+    getEditorHolder: function (id, silent = false) {
+        let editorHolder = window.blazorMonaco.editors.find(e => e.id === id);
+        if (!editorHolder) {
+            if (silent != false) {
+                if (silent != true) // If silent is null, log a warning
+                    console.log("WARNING : Couldn't find the editor with id: " + id + " editors.length: " + window.blazorMonaco.editors.length);
+                return null;
+            }
+            throw "Couldn't find the editor with id: " + id + " editors.length: " + window.blazorMonaco.editors.length;
+        }
+        else if (!editorHolder.editor) {
+            if (silent != false) {
+                if (silent != true) // If silent is null, log a warning
+                    console.log("WARNING : editor is null for editorHolder: " + editorHolder);
+                return null;
+            }
+            throw "editor is null for editorHolder: " + editorHolder;
+        }
+        return editorHolder;
+    },
+
+    getEditor: function (id, silent = false) {
+        let editorHolder = this.getEditorHolder(id, silent);
+        return editorHolder == null ? null : editorHolder.editor;
+    },
+
+    getEditorLineNumberFromDotnet: function (editorId, lineNumber) {
+        const editorHolder = this.getEditorHolder(editorId, true);
+        if (editorHolder == null) {
+            return "";
+        }
+
+        let lineNumbersCache = editorHolder.lineNumbersCache;
+        if (lineNumbersCache == null) {
+            lineNumbersCache = editorHolder.lineNumbersCache = {};
+            lineNumbersCache.Promises = {};
+        }
+
+        let lineNumberVal = lineNumbersCache[lineNumber];
+        if (lineNumberVal != null) {
+            return lineNumberVal;
+        }
+
+        lineNumbersCache[lineNumber] = "";
+        lineNumbersCache.Promises[lineNumber] = editorHolder.dotnetRef.invokeMethodAsync("LineNumbersCallback", lineNumber)
+            .then(result => {
+                lineNumbersCache[lineNumber] = result;
+                delete lineNumbersCache.Promises[lineNumber];
+                if (Object.keys(lineNumbersCache.Promises).length == 0) {
+                    this.redrawLineNumbers(editorId);
+                }
+            })
+            .catch(err => {
+                console.log("BlazorMonaco: Error in LineNumbersCallback(" + lineNumber + ") : " + err);
+                delete lineNumbersCache.Promises[lineNumber];
+                if (Object.keys(lineNumbersCache.Promises).length == 0) {
+                    this.redrawLineNumbers(editorId);
+                }
+            });
+        return "";
+    },
+
+    reloadLineNumbers: function (editorId) {
+        const editorHolder = this.getEditorHolder(editorId, true);
+        if (editorHolder == null) {
+            return;
+        }
+        editorHolder.lineNumbersCache = null;
+        this.redrawLineNumbers(editorId);
+    },
+
+    redrawLineNumbers: function (editorId) {
+        const editor = this.getEditor(editorId, true);
+        if (editor == null) {
+            return;
+        }
+        const optionValue = editor.getOption(monaco.editor.EditorOptions.lineNumbers.id);
+        if (optionValue.renderType == monaco.editor.RenderLineNumbersType.Custom) {
+            editor.updateOptions({
+                lineNumbers: (lineNumber) => {
+                    return this.getEditorLineNumberFromDotnet(editorId, lineNumber);
+                }
+            });
+        }
+    },
+
     convertUriToString: function (obj) {
         if (obj == null)
             return obj;
@@ -83,9 +169,9 @@ window.blazorMonaco.editor = {
             console.log("WARNING : Please check that you have the script tag for editor.main.js in your index.html file");
 
         if (options.lineNumbers == "function") {
-            options.lineNumbers = function (lineNumber) {
-                return dotnetRef.invokeMethod("LineNumbersCallback", lineNumber);
-            }
+            options.lineNumbers = (lineNumber) => {
+                return this.getEditorLineNumberFromDotnet(id, lineNumber);
+            };
         }
 
         var editor = monaco.editor.create(document.getElementById(id), options, override);
@@ -111,9 +197,9 @@ window.blazorMonaco.editor = {
             console.log("WARNING : Please check that you have the script tag for editor.main.js in your index.html file");
 
         if (options.lineNumbers == "function") {
-            options.lineNumbers = function (lineNumber) {
-                return dotnetRef.invokeMethod("LineNumbersCallback", lineNumber);
-            }
+            options.lineNumbers = (lineNumber) => {
+                return this.getEditorLineNumberFromDotnet(id, lineNumber);
+            };
         }
 
         var editor = monaco.editor.createDiffEditor(document.getElementById(id), options, override);
@@ -195,32 +281,6 @@ window.blazorMonaco.editor = {
 
     setTheme: function (theme) {
         monaco.editor.setTheme(theme);
-    },
-
-    getEditorHolder: function (id, silent = false) {
-        let editorHolder = window.blazorMonaco.editors.find(e => e.id === id);
-        if (!editorHolder) {
-            if (silent != false) {
-                if (silent != true) // If silent is null, log a warning
-                    console.log("WARNING : Couldn't find the editor with id: " + id + " editors.length: " + window.blazorMonaco.editors.length);
-                return null;
-            }
-            throw "Couldn't find the editor with id: " + id + " editors.length: " + window.blazorMonaco.editors.length;
-        }
-        else if (!editorHolder.editor) {
-            if (silent != false) {
-                if (silent != true) // If silent is null, log a warning
-                    console.log("WARNING : editor is null for editorHolder: " + editorHolder);
-                return null;
-            }
-            throw "editor is null for editorHolder: " + editorHolder;
-        }
-        return editorHolder;
-    },
-
-    getEditor: function (id, silent = false) {
-        let editorHolder = this.getEditorHolder(id, silent);
-        return editorHolder == null ? null : editorHolder.editor;
     },
 
     //#endregion


### PR DESCRIPTION
The `lineNumbers` option was not working for server apps as server apps need the dotnet interop call to be async where Monaco Editor requires a sync JS function.

Here is an explanation of the new flow;
- A new JS-side cache is added for the line numbers.
- When MonacoEditor requests a line number for the first time, a dotnet call is initiated and an empty string is returned as the line number.
- When an async dotnet call completes, it adds the returned value to the JS-side cache.
- When all active dotnet calls complete, the line numbers are redrawn. In this redraw, the lineNumbers JS function returns the cached values and Monaco Editor displays these values as the line numbers.
- Also, a new editor instance method named `ReloadLineNumbers` is added. It can be used if the dotnet side needs to reset the JS-side cache and provide new line numbers.