### PR TITLE
Handle ObjectDisposedException during Monaco editor initialization when component is disposed

### DIFF
--- a/BlazorMonaco/StandaloneCodeEditor.razor.cs
+++ b/BlazorMonaco/StandaloneCodeEditor.razor.cs
@@ -62,8 +62,15 @@ namespace BlazorMonaco.Editor
                     options.LineNumbersLambda = null;
                 }
 
-                // Create the editor
-                await Global.Create(JsRuntime, Id, options, null, _dotnetObjectRef);
+                try
+                {
+                    // Create the editor
+                    await Global.Create(JsRuntime, Id, options, null, _dotnetObjectRef);
+                }
+                catch (ObjectDisposedException)
+                {
+                    // Gracefully handle the case where the component is disposed in frontend before the editor is initialized.
+                }
             }
             await base.OnAfterRenderAsync(firstRender);
         }

--- a/BlazorMonaco/StandaloneDiffEditor.razor.cs
+++ b/BlazorMonaco/StandaloneDiffEditor.razor.cs
@@ -54,12 +54,19 @@ namespace BlazorMonaco.Editor
                     options.LineNumbersLambda = null;
                 }
 
-                // Create the bridges for the inner editors
-                _originalEditor = StandaloneCodeEditor.CreateVirtualEditor(JsRuntime, Id + "_original");
-                _modifiedEditor = StandaloneCodeEditor.CreateVirtualEditor(JsRuntime, Id + "_modified");
+                try
+                {
+                    // Create the bridges for the inner editors
+                    _originalEditor = StandaloneCodeEditor.CreateVirtualEditor(JsRuntime, Id + "_original");
+                    _modifiedEditor = StandaloneCodeEditor.CreateVirtualEditor(JsRuntime, Id + "_modified");
 
-                // Create the editor
-                await Global.CreateDiffEditor(JsRuntime, Id, options, null, _dotnetObjectRef, OriginalEditor._dotnetObjectRef, ModifiedEditor._dotnetObjectRef);
+                    // Create the editor
+                    await Global.CreateDiffEditor(JsRuntime, Id, options, null, _dotnetObjectRef, OriginalEditor._dotnetObjectRef, ModifiedEditor._dotnetObjectRef);
+                }
+                catch (ObjectDisposedException)
+                {
+                    // Gracefully handle the case where the component is disposed in frontend before the editor is initialized.
+                }
             }
             await base.OnAfterRenderAsync(firstRender);
         }


### PR DESCRIPTION
This PR adds a try-catch block around the Global.Create call to gracefully handle a potential ObjectDisposedException. This can occur if the Blazor component is disposed before the Monaco editor is fully initialized on the frontend.

**Motivation**
In scenarios where multiple Monaco editors are used—for example, within a tab control where each tab hosts its own editor—this exception can occur when a tab is closed while the editor is still initializing. If the component is disposed before initialization completes, Global.Create throws an ObjectDisposedException. This change ensures the exception is safely ignored, preventing unexpected runtime errors during such interactions.

```
Error: System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'Microsoft.JSInterop.DotNetObjectReference`1[[BlazorMonaco.Editor.Editor, BlazorMonaco, Version=3.3.0.0, Culture=neutral, PublicKeyToken=null]]'.
   at Microsoft.JSInterop.JSRuntime.TrackObjectReference[TValue](DotNetObjectReference`1 dotNetObjectReference)
   at Microsoft.JSInterop.Infrastructure.DotNetObjectReferenceJsonConverter`1.Write(Utf8JsonWriter writer, DotNetObjectReference`1 value, JsonSerializerOptions options)
   at System.Text.Json.Serialization.JsonConverter`1.TryWrite(Utf8JsonWriter writer, T& value, JsonSerializerOptions options, WriteStack& state)
   at System.Text.Json.Serialization.JsonConverter`1.TryWriteAsObject(Utf8JsonWriter writer, Object value, JsonSerializerOptions options, WriteStack& state)
   at System.Text.Json.Serialization.JsonConverter`1.TryWrite(Utf8JsonWriter writer, T& value, JsonSerializerOptions options, WriteStack& state)
   at System.Text.Json.Serialization.JsonCollectionConverter`2.OnTryWrite(Utf8JsonWriter writer, TCollection value, JsonSerializerOptions options, WriteStack& state)
   at System.Text.Json.Serialization.JsonConverter`1.TryWrite(Utf8JsonWriter writer, T& value, JsonSerializerOptions options, WriteStack& state)
   at System.Text.Json.Serialization.JsonConverter`1.WriteCore(Utf8JsonWriter writer, T& value, JsonSerializerOptions options, WriteStack& state)
   at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1.Serialize(Utf8JsonWriter writer, T& rootValue, Object rootValueBoxed)
   at System.Text.Json.JsonSerializer.WriteString[TValue](TValue& value, JsonTypeInfo`1 jsonTypeInfo)
   at Microsoft.JSInterop.JSRuntime.InvokeAsync[TValue](Int64 targetInstanceId, String identifier, CancellationToken cancellationToken, Object[] args)
   at Microsoft.JSInterop.JSRuntime.InvokeAsync[TValue](Int64 targetInstanceId, String identifier, Object[] args)
   at Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync(IJSRuntime jsRuntime, String identifier, Object[] args)
   at BlazorMonaco.Helpers.JsRuntimeExt.SafeInvokeAsync(IJSRuntime jsRuntime, String identifier, Object[] args)
   at BlazorMonaco.Editor.Global.Create(IJSRuntime jsRuntime, String domElementId, StandaloneEditorConstructionOptions options, EditorOverrideServices overrideServices, DotNetObjectReference`1 dotnetObjectRef)
   at BlazorMonaco.Editor.StandaloneCodeEditor.OnAfterRenderAsync(Boolean firstRender)
```

**Impact**
This change is minimal and non-invasive. It introduces no functional changes to the normal initialization path and only affects a narrow edge case.